### PR TITLE
Update README.md to fix trailing / omission in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# allianceauth_oidc
+    # allianceauth_oidc
 
 ## Allianceauth OIDC Provider
 
@@ -75,7 +75,7 @@ Please see [this](https://django-oauth-toolkit.readthedocs.io/en/stable/oidc.htm
 - Authorization: `https://your.url/o/authorize/`
 - Token: `https://your.url/o/token/`
 - Profile: `https://your.url/o/userinfo/`
-- Issuer `https://your.url/o`
+- Issuer `https://your.url/o/`
 
 ### Claims
 


### PR DESCRIPTION
Since 0.0.1b7 (aka 0.0.7 Beta 7) there is now a trailing / included in the issuer url payload. 

3rd party apps should be configured to include this trailing / or risk their authentication process/flow to fail due to incorrect payload.